### PR TITLE
Update bp_intro_protocol_overview.md

### DIFF
--- a/rfc/text/basic/bp_intro_protocol_overview.md
+++ b/rfc/text/basic/bp_intro_protocol_overview.md
@@ -6,11 +6,9 @@ The PubSub messaging pattern defines three roles: _Subscribers_ and _Publishers_
 
 The routed RPC messaging pattern also defines three roles: _Callers_ and _Callees_, which communicate via a _Dealer_.
 
-WAMP Connections are established by _Clients_ to a _Router_. Connections can use any transport that is message-based, ordered, reliable and bi-directional, with WebSocket as the default transport.
+A _Router_ is a component which implements one or both of the Broker and Dealer roles. A _Client_ is a component which implements any or all of the Subscriber, Publisher, Caller, or Callee roles.
 
-A Router is a component which implements one or both of the Broker and Dealer roles. A Client is a component which implements any or all of the Subscriber, Publisher, Caller, or Callee roles.
-
-WAMP _Connections_ are established by Clients to a Router. Connections can use any transport which is message-oriented, ordered, reliable and bi-directional, with WebSocket as the default transport.
+WAMP _Connections_ are established by Clients to a Router. Connections can use any _transport_ that is message-based, ordered, reliable and bi-directional, with WebSocket as the default transport.
 
 WAMP _Sessions_ are established over a WAMP Connection. A WAMP Session is joined to a _Realm_ on a Router. Routing occurs only between WAMP Sessions that have joined the same Realm.
 


### PR DESCRIPTION
Connections were introduced twice; should be introduced after Router and Client have been introduced. How about 'transport'?
Some github-bug also changed the 'Wamp advanced profile' section, no idea why (I did not do it)