### PR TITLE
(#255) Fix lack of specification

### DIFF
--- a/rfc/text/basic/bp_sessions.md
+++ b/rfc/text/basic/bp_sessions.md
@@ -41,7 +41,7 @@ In the WAMP Basic Profile without session authentication the Router will reply w
 
 A WAMP session starts its lifetime when the Router has sent a `WELCOME` message to the Client, and ends when the underlying transport closes or when the session is closed explicitly by either peer sending the `GOODBYE` message (see below).
 
-It is a protocol error to receive a second `HELLO` message during the lifetime of the session and the Peer must fail the session if that happens.
+It is a [protocol error](#protocol_error) to receive a second `HELLO` message during the lifetime of the session and the Peer MUST close the session if that happens.
 
 #### Client: Role and Feature Announcement
 

--- a/rfc/text/basic/bp_transports.md
+++ b/rfc/text/basic/bp_transports.md
@@ -77,3 +77,16 @@ The diagram below illustrates the full transport connection and session lifecycl
         ,--+---.                                    ,--+---.
         | Peer |                                    | Peer |
         `------'                                    `------'
+
+
+### Protocol errors {#protocol_errors}
+
+WAMP implementations MUST close sessions (disposing all of their resources such as subscriptions and registrations) on protocol errors caused by offending peers.
+
+Those implementations that MIGHT have chosen to tie the lifetime of the underlying transport connection for a WAMP connection to that of a WAMP session MUST also close the transport connection if any protocol error occurs.
+
+Following scenarios have to be considered protocol errors:
+
+ - Receiving messages implicitly and clearly unexpected for the current state (such as receiving ``GOODBYE`` if no session has been established yet or receiving ``ABORT`` in response to ``PUBLISH``).
+ 
+ - Any other exceptional scenario explicitly defined in any relevant section of this specification below (such as receiving a second ``HELLO`` within the lifetime of a session). 


### PR DESCRIPTION
This commit explicitly defines what protocol errors are and what
peers shall do when those happen.