### PR TITLE
Explicitly state format of signature string

### DIFF
--- a/rfc/text/advanced/ap_authentication_cra.md
+++ b/rfc/text/advanced/ap_authentication_cra.md
@@ -53,7 +53,7 @@ The client needs to compute the signature as follows:
 
 That is, compute the HMAC-SHA256 using the shared `secret` over the `challenge`.
 
-After computing the signature, the client will send an `AUTHENTICATE` message containing the signature:
+After computing the signature, the client will send an `AUTHENTICATE` message containing the signature, as a base64-encoded string:
 
 {align="left"}
 ```javascript


### PR DESCRIPTION
Example shows what appears to be a base64-encoded string in the CRA response, but the format needs to be explicitly stated.