### PR TITLE
Added special namespace for GOODBYE messages

### DIFF
--- a/rfc/text/basic/bp_sessions.md
+++ b/rfc/text/basic/bp_sessions.md
@@ -208,23 +208,23 @@ where
 
 {align="left"}
         [6, {"message": "The host is shutting down now."},
-            "wamp.error.system_shutdown"]
+            "wamp.close.system_shutdown"]
 
 and the other peer replies
 
 {align="left"}
-        [6, {}, "wamp.error.goodbye_and_out"]
+        [6, {}, "wamp.close.goodbye_and_out"]
 
 
 *Example*. One Peer initiates closing
 
 {align="left"}
-        [6, {}, "wamp.error.close_realm"]
+        [6, {}, "wamp.close.close_realm"]
 
 and the other peer replies
 
 {align="left"}
-        [6, {}, "wamp.error.goodbye_and_out"]
+        [6, {}, "wamp.close.goodbye_and_out"]
 
 
 ### Difference between ABORT and GOODBYE

--- a/rfc/text/basic/bp_uris.md
+++ b/rfc/text/basic/bp_uris.md
@@ -45,17 +45,17 @@ A call failed since the given argument types or values are not acceptable to the
 The Peer is shutting down completely - used as a `GOODBYE` (or `ABORT`) reason.
 
 {align="left"}
-        wamp.error.system_shutdown
+        wamp.close.system_shutdown
 
 The Peer want to leave the realm - used as a `GOODBYE` reason.
 
 {align="left"}
-        wamp.error.close_realm
+        wamp.close.close_realm
 
 A Peer acknowledges ending of a session - used as a `GOODBYE` reply reason.
 
 {align="left"}
-        wamp.error.goodbye_and_out
+        wamp.close.goodbye_and_out
 
 A Peer received invalid WAMP protocol message (e.g. `HELLO` message after session was already established) - used as a `ABORT` reply reason.
 


### PR DESCRIPTION
As we all agreed in #192 . Moved GOODBYE URIs to `close` namespace.