### PR TITLE
Add arguments for wamp.session.on_leave and wamp.subscription.on_delete

### DIFF
--- a/rfc/text/advanced/ap_pubsub_subscription_meta_api.md
+++ b/rfc/text/advanced/ap_pubsub_subscription_meta_api.md
@@ -70,11 +70,11 @@ Fired when a session is removed from a subscription. The event payload consists 
 
 ###### wamp.subscription.on_delete
 
-Fired when a subscription is deleted after the last session attached to it has been removed. The event payload consists of positional arguments:
+Fired when a subscription is deleted after the last session attached to it has been removed. The event payload consists of three positional arguments:
 
 * `session|id`: ID of the last session being removed from a subscription.
 * `subscription|id`: ID of the subscription being deleted.
-
+* `topic|uri`: The URI of the topic.
 
 
 #### Subscription Meta-Procedures

--- a/rfc/text/advanced/ap_session_meta_api.md
+++ b/rfc/text/advanced/ap_session_meta_api.md
@@ -33,9 +33,11 @@ Fired when a session joins a realm on the router. The event payload consists of 
 
 ##### wamp.session.on_leave
 
-Fired when a session leaves a realm on the router or is disconnected. The event payload consists of a single positional argument `session|id` with the session ID of the session that left.
+Fired when a session leaves a realm on the router or is disconnected. The event payload consists of three positional arguments:
 
-
+* `session|id` - The session ID of the session that left
+* `authid`|string` - The authentication ID of the session that left
+* `authrole|string` - The authentication role of the session that left
 
 #### Session Meta Procedures
 


### PR DESCRIPTION
This PR fixes #238 and #287 by providing additional information on items that are removed from the realm, making that information otherwise unavailable.