### PR TITLE
Document progressive call results cancellation

### DIFF
--- a/rfc/text/advanced/ap_rpc_call_canceling.md
+++ b/rfc/text/advanced/ap_rpc_call_canceling.md
@@ -94,9 +94,6 @@ Message flow during call canceling when *Callee* supports this feature and mod
            |                 |    INTERRUPT    |    
            |                 | ---------------->    
            |                 |                 |    
-           |                 |      ERROR      |    
-           |                 | <----------------    
-           |                 |                 |    
         ,--+---.          ,--+---.          ,--+---.
         |Caller|          |Dealer|          |Callee|
         `------'          `------'          `------'
@@ -117,6 +114,7 @@ Options:
 {align="left"}
         CANCEL.Options.mode|string == "skip" | "kill" | "killnowait"
 
+Note: After the router sends an `INTERRUPT` when mode="killnowait", any responses from the Callee are ignored.  This means that it is not necessary for the Callee to respond with an `ERROR` message, when mode="killnowait", since the router ignores it.
 
 #### Feature Announcement
 

--- a/rfc/text/advanced/ap_rpc_progressive_call_results.md
+++ b/rfc/text/advanced/ap_rpc_progressive_call_results.md
@@ -275,11 +275,54 @@ The progressive `YIELD` and progressive `RESULT` may also be empty, e.g. when th
 
 Even if a *Caller* has indicated its expectation to receive progressive results by setting `CALL.Options.receive_progress|bool := true`, a *Callee* is **not required** to produce progressive results. `CALL.Options.receive_progress` and `INVOCATION.Details.receive_progress` are simply indications that the *Caller* is prepared to process progressive results, should there be any produced. In other words, *Callees* are free to ignore such `receive_progress` hints at any time.
 
+#### Progressive Call Result Cancellation
+
+Upon receiving a `YIELD` message from a _Callee_ with `YIELD.Options.progress == true` (for a call that is still ongoing), if the original _Caller_ is no longer available (has left the realm), then the _Dealer_ will send an `INTERRUPT` to the _Callee_.  The `INTERRUPT` will have `Options.mode` set to `"killnowait"` to indicate to the client that no response should be sent to the `INTERRUPT`. This `INTERRUPT` in only sent in response to a progressive `YIELD` (`Details.progress == true`), and is not sent in response to a normal or final `YIELD`.
+```
+[INTERRUPT, INVOCATION.Request|id, Options|dict]
+```
+Options:
+```
+INTERRUPT.Options.mode|string == "killnowait"
+```
+
+Progressive call result cancellation closes an important safety gap: In cases where progressive results are used to stream data to callers, and network connectivity is unreliable, callers my often get disconnected in the middle of receiving progressive results. Recurring connect, call, disconnect cycles can quickly build up callees streaming results to dead callers. This can overload the router and further degrade network connectivity.
+
+The message flow for progressive results involves:
+
+     ,------.           ,------.          ,------.
+     |Caller|           |Dealer|          |Callee|
+     `--+---'           `--+---'          `--+---'
+        |       CALL       |                 |
+        | ----------------->                 |
+        |                  |                 |
+        |                  |    INVOCATION   |
+        |                  | ---------------->
+        |                  |                 |
+        |                  | YIELD (progress)|
+        |                  | <----------------
+        |                  |                 |
+        | RESULT (progress)|                 |
+        | <-----------------                 |
+     ,--+---.              |                 |
+     |Caller|              |                 |
+     `------'              | YIELD (progress)|
+      (gone)               | <----------------
+                           |                 |
+                           |    INTERRUPT    |    
+                           | ---------------->    
+                           |                 |    
+                        ,--+---.          ,--+---.
+                        |Dealer|          |Callee|
+                        `------'          `------'
+
+Note: Any `ERROR` returned by the Callee, in response to the `INTERRUPT`, is ignored (same as in call canceling when mode="killnowait"). So, it is not necessary for the Callee to send an `ERROR` message.
 
 #### Callee
 
 A Callee that does not support progressive results SHOULD ignore any `INVOCATION.Details.receive_progress` flag.
 
+A Callee that supports progressive results, but does not support call canceling will be considered by the router to not support progressive results.
 
 #### Feature Announcement
 
@@ -288,3 +331,5 @@ Support for this advanced feature MUST be announced by *Callers* (`role := "call
 {align="left"}
         HELLO.Details.roles.<role>.features.
              progressive_call_results|bool := true
+
+Additionally, _Callees_ and _Dealers_ MUST support Call Canceling, which is required for canceling progressive results if the original _Caller_ leaves the realm. If a _Callee_ supports Progressive Call Results, but not Call Canceling, then the _Dealer_ disregards the _Callees_ Progressive Call Results feature.


### PR DESCRIPTION
This documents WAMP behavior when a caller leaves the realm while receiving
progressive call results.

Additionally documents that ERROR message response from Callee is not needed
after a call cancelation INTERRUPT, when mode="killnowait", since the router
will ignore it.

This fixes issue #319 