### PR TITLE
Fix typos and clarify some grammar

### DIFF
--- a/rfc/draft-oberstet-hybi-crossbar-wamp.md
+++ b/rfc/draft-oberstet-hybi-crossbar-wamp.md
@@ -115,7 +115,7 @@ For each building block, WAMP only assumes a defined set of requirements, which 
 
 # Publish and Subscribe
 
-All of the following features for Publish & Subscribe are mandatory for WAMP Basic Profile implementations supporting the respective roles, i.e. *Publisher*, *Subscriber* and *Dealer*.
+All of the following features for Publish & Subscribe are mandatory for WAMP Basic Profile implementations supporting the respective roles, i.e. *Publisher*, *Subscriber* and *Broker*.
 
 
 {{rfc/text/basic/bp_pubsub_subscribing_and_unsubscribing.md}}

--- a/rfc/text/advanced/ap_rpc_call_timeout.md
+++ b/rfc/text/advanced/ap_rpc_call_timeout.md
@@ -2,9 +2,9 @@
 
 #### Feature Definition
 
-A *Caller* might want to issue a call providing a *timeout* for the call to finish.
+A *Caller* might want to issue a call and provide a *timeout* after which the call will finish.
 
-A *timeout* allows to **automatically** cancel a call after a specified time either at the *Callee* or at the *Dealer*.
+A *timeout* allows for **automatic** cancellation of a call after a specified time either at the *Callee* or at the *Dealer*.
 
 A *Caller* specifies a timeout by providing
 

--- a/rfc/text/basic/bp_pubsub_publishing_and_events.md
+++ b/rfc/text/basic/bp_pubsub_publishing_and_events.md
@@ -50,7 +50,7 @@ where
 * `Arguments` is a list of application-level event payload elements. The list may be of zero length.
 * `ArgumentsKw` is an optional dictionary containing application-level event payload, provided as keyword arguments. The dictionary may be empty.
 
-If the Broker is able to fulfill and allowing the publication, the Broker will send the event to all current Subscribers of the topic of the published event.
+If the Broker allows and is able to fulfill the publication, the Broker will send the event to all current Subscribers of the topic of the published event.
 
 By default, publications are unacknowledged, and the Broker will not respond, whether the publication was successful indeed or not. This behavior can be changed with the option `PUBLISH.Options.acknowledge|bool` (see below).
 


### PR DESCRIPTION
Just some clarifying changes.
- The description for section 9 (Publish and Subscribe) says that it defines implementation details for a *dealer* where it should say *broker*. It even says it's for a *broker* in the next sub-section.
- A couple of grammar and sentence rearrangements