### PR TITLE
Fix number of messages in bp_messages.md

### DIFF
--- a/rfc/text/basic/bp_messages.md
+++ b/rfc/text/basic/bp_messages.md
@@ -247,7 +247,7 @@ Actual yield from an endpoint sent by a Callee to Dealer.
 
 ## Message Codes and Direction
 
-The following table lists the message type code for all 20 messages defined in the WAMP basic profile and their direction between peer roles.
+The following table lists the message type code for all messages defined in the WAMP basic profile and their direction between peer roles.
 
 Reserved codes may be used to identify additional message types in future standards documents.
 

--- a/rfc/text/basic/bp_messages.md
+++ b/rfc/text/basic/bp_messages.md
@@ -247,7 +247,7 @@ Actual yield from an endpoint sent by a Callee to Dealer.
 
 ## Message Codes and Direction
 
-The following table lists the message type code for all 25 messages defined in the WAMP basic profile and their direction between peer roles.
+The following table lists the message type code for all 20 messages defined in the WAMP basic profile and their direction between peer roles.
 
 Reserved codes may be used to identify additional message types in future standards documents.
 


### PR DESCRIPTION
I thought maybe the 25 was also including the Advanced messages, but there are only 4 of those and the surrounding text here clearly refers to the Basic messages. Or did I miss something?