### PR TITLE
Add WAMPex

### DIFF
--- a/docs/implementations.rst
+++ b/docs/implementations.rst
@@ -57,6 +57,7 @@ Swamp_              Swift                               WAMP client library in p
 wampcc_             C++                                 A C++ WAMP library that aims to depend only on C libraries. Includes a basic router.
 WAMP_POCO_          C++                                 A fork of AutobahnCpp that is using `POCO <http://pocoproject.org/>`_ instead of Boost.
 wamped_             C++                                 Intended for running on `ARM mbed OS <https://www.mbed.com/en/>`_. Experimental.
+WAMPex_             Elixir                              Elixir client library that implements the complete client Basic Profile and much of the Advanced Profile. Defaults to msgpack over WebSocket, but JSON is supported as well as raw TCP sockets.
 WampSyncClient_      PHP                                 Synchronous (blocking) PHP client implementing Caller and Publisher roles
 wamprx.js_          TypeScript                          Simple WAMP TypeScript client-side implementation (of course also usable in JavaScript). It heavily relies on RxJS.
 WampSharp_          C#                                  C# implementation of WAMP: both client and router roles, both JSON and `MessagePack <http://msgpack.org/>`_ support.
@@ -131,6 +132,7 @@ Wiola_              Lua                                 Router implementation in
 .. _wampcc: https://github.com/darrenjs/wampcc
 .. _WAMP_POCO: https://github.com/rafzi/WAMP_POCO
 .. _wamped: https://github.com/alvistar/wamped
+.. _WAMPex: https://gitlab.com/entropealabs/wampex
 .. _WampSyncClient: https://github.com/jszczypk/WampSyncClient
 .. _wamprt: https://github.com/Orange-OpenSource/wamp.rt
 .. _wamprx.js: https://github.com/Jopie64/wamprx.js


### PR DESCRIPTION
Adds WAMPex to the list of client implementations. WAMPex is a pure Elixir implementation of a WAMP client.