### PR TITLE
Editorial Correction - "an URI" for "a URI"

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -117,7 +117,7 @@ peer resides and how to reach it. This knowledge is encapsulated in
 the *Dealer*
 
 With WAMP, a *Callee* registers a procedure at a *Dealer* under an abstract
-name: an URI identifying the procedure. When a *Caller* wants to call a remote
+name: a URI identifying the procedure. When a *Caller* wants to call a remote
 procedure, it talks to the *Dealer* and only provides the URI of the
 procedure to be called plus any call arguments. The *Dealer* will
 look up the procedure to be invoked in his book of registered procedures.

--- a/rfc/text/advanced/ap_rpc_registration_meta_api.md
+++ b/rfc/text/advanced/ap_rpc_registration_meta_api.md
@@ -17,7 +17,7 @@ Meta-events are created by the router itself. This means that the events as well
 
 A client can subscribe to the following registration meta-events, which cover the lifecycle of a registration:
 
-* `wamp.registration.on_create`: Fired when a registration is created through a registration request for an URI which was previously without a registration.
+* `wamp.registration.on_create`: Fired when a registration is created through a registration request for a URI which was previously without a registration.
 * `wamp.registration.on_register`: Fired when a *Callee* session is added to a registration.
 * `wamp.registration.on_unregister`: Fired when a *Callee* session is removed from a registration.
 * `wamp.registration.on_delete`: Fired when a registration is deleted after the last *Callee* session attached to it has been removed.
@@ -31,7 +31,7 @@ Similarly, the `wamp.registration.on_delete` event MUST be preceded by a `wamp.r
 
 ###### wamp.registration.on_create
 
-Fired when a registration is created through a registration request for an URI which was previously without a registration. The event payload consists of positional arguments:
+Fired when a registration is created through a registration request for a URI which was previously without a registration. The event payload consists of positional arguments:
 
 - `session|id`: The session ID performing the registration request.
 - `RegistrationDetails|dict`: Information on the created registration.

--- a/rfc/text/advanced/ap_rpc_shared_registration.md
+++ b/rfc/text/advanced/ap_rpc_shared_registration.md
@@ -4,7 +4,7 @@ Feature status: **alpha**
 
 #### Feature Definition
 
-As a default, only a single **Callee** may register a procedure for an URI.
+As a default, only a single **Callee** may register a procedure for a URI.
 
 There are use cases where more flexibility is required. As an example, for an application component with a high computing load, several instances may run, and load balancing of calls across these may be desired. As another example, in an application a second or third component providing a procedure may run, which are only to be called in case the primary component is no longer reachable (hot standby).
 

--- a/rfc/text/basic/bp_pubsub_publishing_and_events.md
+++ b/rfc/text/basic/bp_pubsub_publishing_and_events.md
@@ -99,7 +99,7 @@ When the request for publication cannot be fulfilled by the Broker, and `PUBLISH
 where
 
  * `PUBLISH.Request` is the ID from the original publication request.
- * `Error` is an URI that gives the error of why the request could not be fulfilled.
+ * `Error` is a URI that gives the error of why the request could not be fulfilled.
 
 *Example*
 

--- a/rfc/text/basic/bp_pubsub_subscribing_and_unsubscribing.md
+++ b/rfc/text/basic/bp_pubsub_subscribing_and_unsubscribing.md
@@ -53,7 +53,7 @@ where
 
  * `Request` MUST be a random, ephemeral ID chosen by the Subscriber and used to correlate the Broker's response with the request.
  * `Options` MUST be a dictionary that allows to provide additional subscription request details in a extensible way. This is described further below.
- * `Topic` is the topic the Subscriber wants to subscribe to and MUST be an URI.
+ * `Topic` is the topic the Subscriber wants to subscribe to and MUST be a URI.
 
 *Example*
 
@@ -94,7 +94,7 @@ When the request for subscription cannot be fulfilled by the Broker, the Broker 
 where
 
  * `SUBSCRIBE.Request` MUST be the ID from the original request.
- * `Error` MUST be an URI that gives the error of why the request could not be fulfilled.
+ * `Error` MUST be a URI that gives the error of why the request could not be fulfilled.
 
 *Example*
 
@@ -147,7 +147,7 @@ When the request fails, the Broker sends an `ERROR`
 where
 
  * `UNSUBSCRIBE.Request` MUST be the ID from the original request.
- * `Error` MUST be an URI that gives the error of why the request could not be fulfilled.
+ * `Error` MUST be a URI that gives the error of why the request could not be fulfilled.
 
 *Example*
 

--- a/rfc/text/basic/bp_rpc_calling_and_invocation.md
+++ b/rfc/text/basic/bp_rpc_calling_and_invocation.md
@@ -246,7 +246,7 @@ where
 
 * `INVOCATION.Request` is the ID from the original `INVOCATION` request previously sent by the Dealer to the Callee.
 * `Details` is a dictionary with additional error details.
-* `Error` is an URI that identifies the error of why the request could not be fulfilled.
+* `Error` is a URI that identifies the error of why the request could not be fulfilled.
 * `Arguments` is a list containing arbitrary, application defined, positional error information. This will be forwarded by the Dealer to the Caller that initiated the call.
 * `ArgumentsKw` is a dictionary containing arbitrary, application defined, keyword-based error information. This will be forwarded by the Dealer to the Caller that initiated the call.
 
@@ -280,7 +280,7 @@ where
 
 * `CALL.Request` is the ID from the original `CALL` request sent by the Caller to the Dealer.
 * `Details` is a dictionary with additional error details.
-* `Error` is an URI identifying the type of error as returned by the Callee to the Dealer.
+* `Error` is a URI identifying the type of error as returned by the Callee to the Dealer.
 * `Arguments` is a list containing the original error payload list as returned by the Callee to the Dealer.
 * `ArgumentsKw` is a dictionary containing the original error payload dictionary as returned by the Callee to the Dealer
 

--- a/rfc/text/basic/bp_rpc_registering_and_unregistering.md
+++ b/rfc/text/basic/bp_rpc_registering_and_unregistering.md
@@ -79,7 +79,7 @@ When the request for registration cannot be fulfilled by the Dealer, the Dealer 
 where
 
 * `REGISTER.Request` is the ID from the original request.
-* `Error` is an URI that gives the error of why the request could not be fulfilled.
+* `Error` is a URI that gives the error of why the request could not be fulfilled.
 
 *Example*
 
@@ -130,7 +130,7 @@ When the unregistration request fails, the Dealer sends an `ERROR` message:
 where
 
 * `UNREGISTER.Request` is the ID from the original request.
-* `Error` is an URI that gives the error of why the request could not be fulfilled.
+* `Error` is a URI that gives the error of why the request could not be fulfilled.
 
 *Example*
 

--- a/rfc/text/basic/bp_sessions.md
+++ b/rfc/text/basic/bp_sessions.md
@@ -121,7 +121,7 @@ Both the Router and the Client may abort a WAMP session by sending an `ABORT` me
 
 where
 
-* `Reason` MUST be an URI.
+* `Reason` MUST be a URI.
 * `Details` MUST be a dictionary that allows to provide additional, optional closing information (see below).
 
 No response to an `ABORT` message is expected.
@@ -177,7 +177,7 @@ A WAMP session starts its lifetime with the Router sending a `WELCOME` message t
 
 where
 
-* `Reason` MUST be an URI.
+* `Reason` MUST be a URI.
 * `Details` MUST be a dictionary that allows to provide additional, optional closing information (see below).
 
 {align="left"}


### PR DESCRIPTION
Pretty simple, just corrected the grammar for a few of the doc pages. Swapped any reference of `an URI` for `a URI`.

Thanks to those of you working on this! My addition is peanuts in comparison.