### PR TITLE
Remove error message that implies callee black-white listing

### DIFF
--- a/rfc/text/advanced/ap_uris.md
+++ b/rfc/text/advanced/ap_uris.md
@@ -10,11 +10,6 @@ A *Peer* requested an interaction with an option that was disallowed by the *Rou
 {align="left"}
         wamp.error.option_not_allowed
 
-A *Dealer* could not perform a call, since a procedure with the given URI is registered, but *Callee Black- and Whitelisting* and/or *Caller Exclusion* lead to the exclusion of (any) *Callee* providing the procedure.
-
-{align="left"}
-        wamp.error.no_eligible_callee
-
 A *Router* rejected client request to disclose its identity
 
 {align="left"}


### PR DESCRIPTION
Callee black-white listing is not a feature in WAMP, yet this error message
implies that it is.  This PR fixes Issue #342