### PR TITLE
Changed event history feature status alpha->beta

### DIFF
--- a/rfc/text/advanced/ap_02_features.md
+++ b/rfc/text/advanced/ap_02_features.md
@@ -33,7 +33,7 @@ Support for advanced features must be announced by the peers which implement the
 | [Subscription Meta API](#pubsub-sub-metapi)               | beta   |   | X |   |    |   |    |
 | [Pattern-based Subscription](#pattern-based-subscription) | stable |   | X | X |    |   |    |
 | [Sharded Subscription](#pubsub-sharded-subscription)      | alpha  |   | X | X |    |   |    |
-| [Event History](#pubsub-event-history)                    | alpha  |   | X | X |    |   |    |
+| [Event History](#pubsub-event-history)                    | beta   |   | X |   |    |   |    |
 | [(Interface) Topic Reflection](#interface-reflection)     | sketch |   | X |   |    |   |    |
 
 


### PR DESCRIPTION
I think Event history feature is well defined now in the spec and there is at least one and half implementations :)
So lets set status to `beta`. When XB will be aligned with the spec we can set it to stable, as there will be 2 broker implementations already. 