### PR TITLE
Define all AA-related error URIs systematically

### DIFF
--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -2,15 +2,10 @@
 
 WAMP pre-defines the following error URIs for the **Advanced Profile**. WAMP peers SHOULD only use the defined error messages.
 
-A *Router* requires authentication, but *Client* does not provide authentication information in *HELLO* message
+A *Router* requires authentication, but *Client* does not provide matching informations in *HELLO* message or does not provide valid informations in *CHALLENGE* message
 
 {align="left"}
-        wamp.error.authentication_required
-
-A *Router* requires authentication, but *Client* didn't provide valid authentication information in *CHALLENGE* message
-
-{align="left"}
-        wamp.error.authentication_failure
+        wamp.error.authentication_failed
 
 A *Dealer* or *Callee* canceled a call previously issued
 

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -2,7 +2,17 @@
 
 WAMP pre-defines the following error URIs for the **Advanced Profile**. WAMP peers SHOULD only use the defined error messages.
 
-A *Dealer* or *Callee* canceled a call previously issued
+A *Router* requires authentication, but *Client* does not provide authentication information in *HELLO* message
+
+{align="left"}
+        wamp.error.authentication_required
+
+A *Router* requires authentication, but *Client* didn't provide valid authentication information in *CHALLENGE* message
+
+{align="left"}
+        wamp.error.authentication_failure
+
+A *Dealer* or *Callee* canceled a call previously issued
 
 {align="left"}
         wamp.error.canceled


### PR DESCRIPTION
Adding two error URIs, as description in PR:

1. A *Router* requires authentication, but *Client* does not provide authentication information in *HELLO* message;
2. A *Router* requires authentication, but *Client* didn't provide valid authentication information in *CHALLENGE* message.