### PR TITLE
[WIP] AA related URIs

### DIFF
--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -19,7 +19,7 @@ The *Client* attempted to authenticate for a non-existing *Role* (`authrole|stri
 {align="left"}
         wamp.error.no_such_role
 
-The *Client* authenticated for a *Principal* (`authid|string`) that does not (or no longer) exists.
+The *Client* authenticated for a non-existing *Principal* (`authid|string`).
 
 {align="left"}
         wamp.error.no_such_principal

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -46,7 +46,7 @@ The *Principal* is not authorized to perform such *Action*.
 {align="left"}
         wamp.error.authorization_denied
 
-Authorization of the *Principal* for the *Action* could not be determined as it failed technically at run-time, and the *Action* is therefor rejected ("fail secure operation").
+Authorization of the *Principal* to perform the given *Action* was rejected due to a technical runtime failure ("fail secure" operation).
 
 {align="left"}
         wamp.error.authorization_failed

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -2,6 +2,62 @@
 
 WAMP pre-defines the following error URIs for the **Advanced Profile**. WAMP peers SHOULD only use the defined error messages.
 
+## Authentication
+
+No authentication method the *Client* offered is accepted.
+
+{align="left"}
+        wamp.error.no_auth_method
+
+The *Client* authenticated for a *Realm* (`realm|string`) that does not (or no longer) exists.
+
+{align="left"}
+        wamp.error.no_such_realm
+
+The *Client* authenticated for a *Role* (`authrole|string`) that does not (or no longer) exists.
+
+{align="left"}
+        wamp.error.no_such_role
+
+The *Client* authenticated for a *Principal* (`authid|string`) that does not (or no longer) exists.
+
+{align="left"}
+        wamp.error.no_such_principal
+
+The authentication as presented by the *Client* is denied (e.g. "wrong password").
+
+{align="left"}
+        wamp.error.authentication_denied
+
+The authentication of the *Client* failed technically, and the *Client* is therefor rejected ("fail secure").
+
+{align="left"}
+        wamp.error.authentication_failed
+
+The *Client* did not authenticate (at all) and a successful (non-anonymous) authentication is required.
+
+{align="left"}
+        wamp.error.authentication_required
+
+## Authorization
+
+The *Client* is not authorized to perform such action.
+
+{align="left"}
+        wamp.error.authorization_denied
+
+Authorization of the *Client* for the action could not be determined as it failed technically.
+
+{align="left"}
+        wamp.error.authorization_failed
+
+Authorization by the *Client* ("capability") is required for each single action.
+
+{align="left"}
+        wamp.error.authorization_required
+
+## Remote Procedure Calls
+
 A *Dealer* or *Callee* canceled a call previously issued
 
 {align="left"}

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -34,7 +34,7 @@ The authentication of the *Client* failed technically at run-time, and the *Clie
 {align="left"}
         wamp.error.authentication_failed
 
-The *Client* did not authenticate (at all) and a successful (non-anonymous) authentication is required.
+The *Client* did not provide the required, non-anonymous, authentication information.
 
 {align="left"}
         wamp.error.authentication_required

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -29,7 +29,7 @@ The authentication as presented by the *Client* is denied (e.g. "wrong password"
 {align="left"}
         wamp.error.authentication_denied
 
-The authentication of the *Client* failed technically at run-time, and the *Client* is therefor rejected ("fail secure operation").
+The *Client* authentication was rejected due to a technical runtime failure ("fail secure" operation).
 
 {align="left"}
         wamp.error.authentication_failed

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -51,7 +51,7 @@ Authorization of the *Principal* to perform the given *Action* was rejected due 
 {align="left"}
         wamp.error.authorization_failed
 
-Authorization of the *Principal* is required for each individual execution of the *Action*. This can be used for capability-based access control.
+Authorization of the *Principal* is required to perform the given *Action*. This can be used for capability-based access control.
 
 {align="left"}
         wamp.error.authorization_required

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -7,7 +7,7 @@ WAMP pre-defines the following error URIs for the **Advanced Profile**. WAMP pee
 No authentication method the *Client* offered is accepted.
 
 {align="left"}
-        wamp.error.no_auth_method
+        wamp.error.no_matching_auth_method
 
 The *Client* attempted to authenticate for a non-existing *Realm* (`realm|string`).
 

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -14,7 +14,7 @@ The *Client* attempted to authenticate for a non-existing *Realm* (`realm|string
 {align="left"}
         wamp.error.no_such_realm
 
-The *Client* attempted to authenticate for a *Role* (`authrole|string`) that does not (or no longer) exists.
+The *Client* attempted to authenticate for a non-existing *Role* (`authrole|string`).
 
 {align="left"}
         wamp.error.no_such_role

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -9,12 +9,12 @@ No authentication method the *Client* offered is accepted.
 {align="left"}
         wamp.error.no_auth_method
 
-The *Client* authenticated for a *Realm* (`realm|string`) that does not (or no longer) exists.
+The *Client* attempted to authenticate for a *Realm* (`realm|string`) that does not (or no longer) exists.
 
 {align="left"}
         wamp.error.no_such_realm
 
-The *Client* authenticated for a *Role* (`authrole|string`) that does not (or no longer) exists.
+The *Client* attempted to authenticate for a *Role* (`authrole|string`) that does not (or no longer) exists.
 
 {align="left"}
         wamp.error.no_such_role

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -29,7 +29,7 @@ The authentication as presented by the *Client* is denied (e.g. "wrong password"
 {align="left"}
         wamp.error.authentication_denied
 
-The authentication of the *Client* failed technically, and the *Client* is therefor rejected ("fail secure").
+The authentication of the *Client* failed technically at run-time, and the *Client* is therefor rejected ("fail secure operation").
 
 {align="left"}
         wamp.error.authentication_failed
@@ -41,17 +41,17 @@ The *Client* did not authenticate (at all) and a successful (non-anonymous) auth
 
 ## Authorization
 
-The *Client* is not authorized to perform such action.
+The *Principal* is not authorized to perform such *Action*.
 
 {align="left"}
         wamp.error.authorization_denied
 
-Authorization of the *Client* for the action could not be determined as it failed technically.
+Authorization of the *Principal* for the *Action* could not be determined as it failed technically at run-time, and the *Action* is therefor rejected ("fail secure operation").
 
 {align="left"}
         wamp.error.authorization_failed
 
-Authorization by the *Client* ("capability") is required for each single action.
+Authorization of the *Principal* is required for each individual execution of the *Action*. This can be used for capability-based access control.
 
 {align="left"}
         wamp.error.authorization_required

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -9,7 +9,7 @@ No authentication method the *Client* offered is accepted.
 {align="left"}
         wamp.error.no_auth_method
 
-The *Client* attempted to authenticate for a *Realm* (`realm|string`) that does not (or no longer) exists.
+The *Client* attempted to authenticate for a non-existing *Realm* (`realm|string`).
 
 {align="left"}
         wamp.error.no_such_realm

--- a/rfc/text/basic/bp_01_introduction.md
+++ b/rfc/text/basic/bp_01_introduction.md
@@ -154,18 +154,6 @@ After the transport and a session have been established, any application compone
 Note that Peers might implement more than one role: e.g. a Peer might act as Caller, Publisher and Subscriber at the same time. Another Peer might act as both a Broker and a Dealer.
 
 
-### Router Implementation Specifics
-
-This specification only deals with the protocol level. Specific WAMP Broker and Dealer implementations may differ in aspects such as support for:
-
-* router networks (clustering and federation),
-* authentication and authorization schemes,
-* message persistence, and,
-* management and monitoring.
-
-The definition and documentation of such Router features is outside the scope of this document.
-
-
 ### Relationship to WebSocket
 
 WAMP uses WebSocket as its default transport binding, and is a registered WebSocket subprotocol.


### PR DESCRIPTION
this PR is supposed to consolidate and cleanup the discussion from https://github.com/wamp-proto/wamp-proto/pull/444 and supersedes the latter

The PR adds:
1. the URIs and descriptions from the discussion above - hopefully
2. it also adds `no_auth_method`, `no_such_realm`, `no_such_role` and `no_such_principal`

I have done 2. after reviewing this whole new section and after reviewing auth code in crossbar/autobahn code. It is necessary there, and I think it makes sense, *but I can remove that again and only keep 1!*. Let me know.
