### PR TITLE
Remove sticky

### DIFF
--- a/rfc/text/advanced/ap_10_rpc_progressive_calls.md
+++ b/rfc/text/advanced/ap_10_rpc_progressive_calls.md
@@ -119,7 +119,7 @@ set `"progress": false` which is the default.
 **Progressive Calls and Shared Registration**
 
 RPCs can have a multiple registrations (see `Shared Registration` feature) with different `<invocation_policies>`.
-In this case, progressive `CALL` messages can be routed to different *Callees*, which can lead to unexpected results.
+However, allowing progressive CALL messages to be routed to different Callees would lead to unexpected results.
 To prevent this the *Dealer* must make a first `INVOCATION` based on `<invocation_policy>` and then route all 
 subsequent `progressive` calls to the same *Callee*.
 

--- a/rfc/text/advanced/ap_10_rpc_progressive_calls.md
+++ b/rfc/text/advanced/ap_10_rpc_progressive_calls.md
@@ -120,20 +120,8 @@ set `"progress": false` which is the default.
 
 RPCs can have a multiple registrations (see `Shared Registration` feature) with different `<invocation_policies>`.
 In this case, progressive `CALL` messages can be routed to different *Callees*, which can lead to unexpected results.
-To bind `INVOCATION` messages to the same *Callee*, the *Caller* can specify the `sticky` option during `CALL`
-
-{align="left"}
-        CALL.Options.sticky|bool := true
-
-
-In this case, the *Dealer* must make a first `INVOCATION` based on `<invocation_policy>` and then route all 
+To prevent this the *Dealer* must make a first `INVOCATION` based on `<invocation_policy>` and then route all 
 subsequent `progressive` calls to the same *Callee*.
-
-If binding all ongoing `progressive` calls to the same *Callee* is not required, the *Caller* can set the `sticky` option to `false`. 
-
-If `CALL.Options.sticky` is not specified, it is treated like `true`, so all `progressive`
-calls go to the same *Callee*.
-
 
 **Progressive Call Cancellation**
 

--- a/rfc/text/advanced/ap_10_rpc_progressive_calls.md
+++ b/rfc/text/advanced/ap_10_rpc_progressive_calls.md
@@ -272,5 +272,4 @@ For reference, here is a list of options that are frozen upon the initial progre
 - `CALL.Options.receive_progress|bool`
 - `CALL.Options.rkey`
 - `CALL.Options.runmode|string`
-- `CALL.Options.sticky|bool`
 - `CALL.Options.timeout|integer`


### PR DESCRIPTION
Removed the sticky option as we discussed.

As previous [PR](https://github.com/wamp-proto/wamp-proto/pull/458) was merged-closed-reverted due to conflicts. Reopening :) 