### PR TITLE
Replaced all NBSP with spaces

### DIFF
--- a/_work/predefined-uris.md
+++ b/_work/predefined-uris.md
@@ -2,11 +2,11 @@
 
 # Predefined URIs
 
-WAMP predefines the following URIs in the *advanced profile*. For URIs, used in *basic profile*, please, see appendix in basic profile specification.
+WAMP predefines the following URIs in the *advanced profile*. For URIs, used in *basic profile*, please, see appendix in basic profile specification.
 
 ## Predefined Errors
 
-*Dealer* or *Callee* canceled a call previously issued
+*Dealer* or *Callee* canceled a call previously issued
 
     wamp.error.canceled
 

--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -278,11 +278,11 @@ well (polling when no change occured).
    :name: rest
 
 `REST <http://en.wikipedia.org/wiki/Representational_State_Transfer>`__
-is neither a library, nor protocol or framework. It's a software
-architecture style. REST stands for "Representational State Transfer"
-and assumes that data should be transfered over network in one
-of the standard formats like HTML, XML or JSON and follows an
-architecture based on 6 limitations:
+is neither a library, nor protocol or framework. It's a software
+architecture style. REST stands for "Representational State Transfer"
+and assumes that data should be transfered over network in one
+of the standard formats like HTML, XML or JSON and follows an
+architecture based on 6 limitations:
 
 -  Uniform Interface
 -  Stateless
@@ -291,18 +291,18 @@ architecture based on 6 limitations:
 -  Layered System
 -  Code on Demand (optional)
 
-In a World Wide Web, RESTful systems use URL for an information unit
-address, and http status codes
-for corresponding \ `CRUD <http://en.wikipedia.org/wiki/Create,_read,_update_and_delete>`__
+In a World Wide Web, RESTful systems use URL for an information unit
+address, and http status codes
+for corresponding \ `CRUD <http://en.wikipedia.org/wiki/Create,_read,_update_and_delete>`__
 operations.
 
-It is difficult to compare the WAMP protocol and a software architecture
-paradigm. They both are multilayered and can use different data
-presentation format. But one of the clearest difference is that WAMP is
+It is difficult to compare the WAMP protocol and a software architecture
+paradigm. They both are multilayered and can use different data
+presentation format. But one of the clearest difference is that WAMP is
 bidirectional, while REST pattern is not. In RESTful applications only
-client acts as initiator for data manipulations, and there is no options
-about how server can send data to client. In contrast to this, WAMP
-workflow allows data to be transfered to and form server.
+client acts as initiator for data manipulations, and there is no options
+about how server can send data to client. In contrast to this, WAMP
+workflow allows data to be transfered to and form server.
 
 Another difference is that REST deliberately uses URLs from the HTTP
 scheme which serve a dual function of **identifying** and **addressing**
@@ -312,11 +312,11 @@ means, the implementation of the procedure can reside anywhere - it's
 location is only known to the WAMP router. This provides location
 transparency for WAMP application components.
 
-There is no problem to use WAMP and REST together. For example, you can
+There is no problem to use WAMP and REST together. For example, you can
 make basic CRUD-operations over HTTP using GET/POST/PUT/DELETE methods,
-and in parallel, use WAMP PubSub service for notifications about
-changes, and WAMP RPC's for making some explicit business logic
-operations (like sending SMS, or batch picture resizing and so on).
+and in parallel, use WAMP PubSub service for notifications about
+changes, and WAMP RPC's for making some explicit business logic
+operations (like sending SMS, or batch picture resizing and so on).
 
 
 .. rubric:: SOAP
@@ -358,18 +358,18 @@ independent addressing and routing right into the protocol.
    :name: socketio
 
 `socket.io <http://socket.io/>`__ is a client-server PubSub service
-implementation written in JavaScript. It uses node.js on server side,
-browser counter part and own communication protocol. Socket.IO uses
-WebSocket under the hood, when it's possible, but also has a polyfill as
+implementation written in JavaScript. It uses node.js on server side,
+browser counter part and own communication protocol. Socket.IO uses
+WebSocket under the hood, when it's possible, but also has a polyfill as
 fallback.
 
-Comparing to WAMP, library allows you to subscribe to different topics,
-has a broadcast messages and message namespaces, which works like
-a realms in WAMP. Binary data transfer is possible, but that needs
+Comparing to WAMP, library allows you to subscribe to different topics,
+has a broadcast messages and message namespaces, which works like
+a realms in WAMP. Binary data transfer is possible, but that needs
 additional modules on both sides
 (`socket.io-stream <https://github.com/nkzawa/socket.io-stream>`__)
-and additional amount of work for developers. They need to program
-that explicitly.
+and additional amount of work for developers. They need to program
+that explicitly.
 
 Socket.IO does not provide remote procedure calls.
 

--- a/rfc/text/advanced/ap_10_rpc_progressive_call_invocations.md
+++ b/rfc/text/advanced/ap_10_rpc_progressive_call_invocations.md
@@ -8,7 +8,7 @@ A *Caller* may issue a call having progressive invocations. This can be useful i
   initiate data structures for a new call, etc.
 
 In such cases, a procedure implemented by a *Callee* and registered at a *Dealer* may be made to receive progressive call invocations,
-where the *Callee* may start processing the incoming data without awaiting the entire set of payload chunks.
+where the *Callee* may start processing the incoming data without awaiting the entire set of payload chunks.
 
 
 **Feature Announcement**

--- a/rfc/text/advanced/ap_12_rpc_call_canceling.md
+++ b/rfc/text/advanced/ap_12_rpc_call_canceling.md
@@ -17,7 +17,7 @@ The message flow between *Callers*, a *Dealer* and *Callees* for canceling remot
  * `INTERRUPT`
  * `ERROR`
 
-A call may be canceled at the *Callee* or at the *Dealer* side. Cancellation behaves differently depending on the mode:
+A call may be canceled at the *Callee* or at the *Dealer* side. Cancellation behaves differently depending on the mode:
 
 * **skip**: The pending call is canceled and `ERROR` is sent immediately back to the caller. No `INTERRUPT` is sent to the callee and the result is discarded when received.
 * **kill**: `INTERRUPT` is sent to the callee, but `ERROR` is not returned to the caller until after the callee has responded to the canceled call. In this case the caller may receive `RESULT` or `ERROR` depending whether the callee finishes processing the invocation or the interrupt first.
@@ -25,7 +25,7 @@ A call may be canceled at the *Callee* or at the *Dealer* side. Cancellation 
 
 If the callee does not support call canceling, then behavior is **skip**.
 
-Message flow during call canceling when *Callee* supports this feature and mode is `kill`
+Message flow during call canceling when *Callee* supports this feature and mode is `kill`
 
 {align="left"}
         ,------.          ,------.          ,------.
@@ -53,7 +53,7 @@ Message flow during call canceling when *Callee* supports this feature and mod
         `------'          `------'          `------'
 
 
-Message flow during call canceling when *Callee* does not support this feature or mode is `skip`
+Message flow during call canceling when *Callee* does not support this feature or mode is `skip`
 
 {align="left"}
         ,------.          ,------.            ,------.
@@ -81,7 +81,7 @@ Message flow during call canceling when *Callee* does not support this feature 
         `------'          `------'            `------'
 
 
-Message flow during call canceling when *Callee* supports this feature and mode is `killnowait`
+Message flow during call canceling when *Callee* supports this feature and mode is `killnowait`
 
 {align="left"}
         ,------.          ,------.          ,------.

--- a/rfc/text/advanced/ap_16_rpc_pattern_based_registration.md
+++ b/rfc/text/advanced/ap_16_rpc_pattern_based_registration.md
@@ -105,13 +105,13 @@ E.g. a *Callee* cannot register to a broad pattern, and then unregister from a s
 
 **Calls matching multiple registrations**
 
-There can be situations, when some call URI matches more then one registration. In this case a call is routed to one and only one best matched RPC registration, or fails with ERROR `wamp.error.no_such_procedure`.
+There can be situations, when some call URI matches more then one registration. In this case a call is routed to one and only one best matched RPC registration, or fails with ERROR `wamp.error.no_such_procedure`.
 
-The following algorithm MUST be applied to find a single RPC registration to which a call is routed:
+The following algorithm MUST be applied to find a single RPC registration to which a call is routed:
 
-1. Check for exact matching registration. If this match exists — use it.
-2. If there are prefix-based registrations, find the registration with the longest prefix match. Longest means it has more URI components matched, e.g. for call URI `a1.b2.c3.d4` registration `a1.b2.c3` has higher priority than registration `a1.b2`. If this match exists — use it.
-3. If there are wildcard-based registrations, find the registration with the longest portion of URI components matched before each wildcard. E.g. for call URI `a1.b2.c3.d4` registration `a1.b2..d4` has higher priority than registration `a1...d4`, see below for more complex examples. If this match exists — use it.
+1. Check for exact matching registration. If this match exists — use it.
+2. If there are prefix-based registrations, find the registration with the longest prefix match. Longest means it has more URI components matched, e.g. for call URI `a1.b2.c3.d4` registration `a1.b2.c3` has higher priority than registration `a1.b2`. If this match exists — use it.
+3. If there are wildcard-based registrations, find the registration with the longest portion of URI components matched before each wildcard. E.g. for call URI `a1.b2.c3.d4` registration `a1.b2..d4` has higher priority than registration `a1...d4`, see below for more complex examples. If this match exists — use it.
 4. If there is no exact match, no prefix match, and no wildcard match, then *Dealer* MUST return ERROR `wamp.error.no_such_procedure`.
 
 *Examples*
@@ -142,7 +142,7 @@ Call request RPC URI: 'a1.b2.c33.d4.e5' →
     select longest one. Use RPC 5
 Call request RPC URI: 'a1.b2.c88.d4.e5.f6.g7' →
     no exact match, no prefix match, 2 wildcard matches (6,7),
-    both having equal first portions (a1.b2), but RPC 6 has longer
+    both having equal first portions (a1.b2), but RPC 6 has longer
     second portion (d4.e5). Use RPC 6
 Call request RPC URI: 'a2.b2.c2.d2.e2' →
     no exact match, no prefix match, no wildcard match.

--- a/rfc/text/advanced/ap_48_uris.md
+++ b/rfc/text/advanced/ap_48_uris.md
@@ -65,7 +65,7 @@ Authorization of the *Principal* is required to perform the given *Action*. This
 
 ## Remote Procedure Calls
 
-A *Dealer* or *Callee* terminated a call that timed out
+A *Dealer* or *Callee* terminated a call that timed out
 
 {align="left"}
         wamp.error.timeout

--- a/rfc/text/basic/bp_04_sessions.md
+++ b/rfc/text/basic/bp_04_sessions.md
@@ -225,7 +225,7 @@ where
 
 No response to an `ABORT` message is expected.
 
-There are few scenarios, when `ABORT` is used:
+There are few scenarios, when `ABORT` is used:
 
 * During session opening, if peer decided to abort connect.
 
@@ -249,7 +249,7 @@ There are few scenarios, when `ABORT` is used:
         [3, {"message": "The realm does not exist."},
             "wamp.error.no_such_realm"]
 
-* After session is opened, when protocol violation happens (see "Protocol errors" section).
+* After session is opened, when protocol violation happens (see "Protocol errors" section).
 
 *Examples*
 
@@ -333,6 +333,6 @@ and the other peer replies
 
 **Difference between ABORT and GOODBYE**
 
-The differences between `ABORT` and `GOODBYE` messages is that `ABORT` is never replied to by a Peer, whereas `GOODBYE` must be replied to by the receiving Peer.
+The differences between `ABORT` and `GOODBYE` messages is that `ABORT` is never replied to by a Peer, whereas `GOODBYE` must be replied to by the receiving Peer.
 
 > Though `ABORT` and `GOODBYE` are structurally identical, using different message types serves to reduce overloaded meaning of messages and simplify message handling code.

--- a/rfc/text/basic/bp_08_uri_reference.md
+++ b/rfc/text/basic/bp_08_uri_reference.md
@@ -43,7 +43,7 @@ A call failed since the given argument types or values are not acceptable to the
 {align="left"}
         wamp.error.invalid_argument
 
-A *Dealer* or *Callee* canceled a call previously issued
+A *Dealer* or *Callee* canceled a call previously issued
 
 {align="left"}
         wamp.error.canceled


### PR DESCRIPTION
Replaced all `NBSP` (that results in (U+00A0) after rendering) with just spaces. So now the spec should look clean