### PR TITLE
Adding terminology page into full spec.

### DIFF
--- a/rfc/wamp-ap.md
+++ b/rfc/wamp-ap.md
@@ -31,7 +31,7 @@ organization = "typedef int GmbH"
 
 {{text/advanced.md}}
 
-{{text/terminology.md}}
+{{text/wamp-terminology.md}}
 
 {{text/backmatter.md}}
 

--- a/rfc/wamp-bp.md
+++ b/rfc/wamp-bp.md
@@ -31,7 +31,7 @@ organization = "typedef int GmbH"
 
 {{text/basic.md}}
 
-{{text/terminology.md}}
+{{text/wamp-terminology.md}}
 
 {{text/backmatter.md}}
 

--- a/rfc/wamp.md
+++ b/rfc/wamp.md
@@ -33,7 +33,7 @@ organization = "typedef int GmbH"
 
 {{text/advanced.md}}
 
-{{text/terminology.md}}
+{{text/wamp-terminology.md}}
 
 {{text/backmatter.md}}
 

--- a/rfc/wamp.md
+++ b/rfc/wamp.md
@@ -33,6 +33,8 @@ organization = "typedef int GmbH"
 
 {{text/advanced.md}}
 
+{{text/terminology.md}}
+
 {{text/backmatter.md}}
 
 {backmatter}


### PR DESCRIPTION
Why not include the terminology into the full specification?