### PR TITLE
Typo and grammar fix.

### DIFF
--- a/rfc/text/advanced/authorization.md
+++ b/rfc/text/advanced/authorization.md
@@ -11,7 +11,7 @@ Performing these actions requires *Clients* to have an open *Session* to the sam
 
 A *Session* is established between a *Client* to a *Router*, and is initiated by a *Client*.
 
-*Session*s MAY be required to *Authenticate* access to a *Realm* hosted by a *Router*.
+*Sessions* MAY be required to *Authenticate* access to a *Realm* hosted by a *Router*.
 
 *Authentication* is the sequence of operations that allow a *Router* to verify the identity of a *Session*, often as a prerequisite to allowing access to resources within a *Realm*.
 
@@ -25,9 +25,9 @@ for that *Session* running in the *Client*.
 
 The triple `(realm, authrole, authid)` is called *Principal*, and a *Session* is authenticated under that *Principal*.
 
-At any moment, there can be zero, one, or many *Session*s with different *session ids* authenticated under the _same_ *Principal*.
+At any moment, there can be zero, one, or many *Sessions* with different *session ids* authenticated under the _same_ *Principal*.
 
-*Session*s MAY be required to *Authorize* in order to perform a specific *Action* on an URI — or an URI pattern — within a *Realm*.
+*Sessions* MAY be required to *Authorize* in order to perform a specific *Action* on an URI - or an URI pattern - within a *Realm*.
 
 This distinction between *Authentication* and *Authorization* follows the established practice called "AAA":
 

--- a/rfc/text/basic/messages.md
+++ b/rfc/text/basic/messages.md
@@ -70,7 +70,7 @@ Sent by a Router to accept a Client. The WAMP session is now open.
 
 #### ABORT
 
-Sent by a Peer*to abort the opening of a WAMP session. No response is expected.
+Sent by a Peer to abort the opening of a WAMP session. No response is expected.
 
 {align="left"}
         [ABORT, Details|dict, Reason|uri]

--- a/rfc/text/basic/remote_procedure_call.md
+++ b/rfc/text/basic/remote_procedure_call.md
@@ -49,7 +49,7 @@ where
 
 * `Request` is a sequential ID in the _session scope_, incremented by the Callee and used to correlate the Dealer's response with the request.
 * `Options` is a dictionary that allows to provide additional registration request details in a extensible way. This is described further below.
-* `Procedure`is the procedure the Callee wants to register
+* `Procedure` is the procedure the Callee wants to register
 
 *Example*
 
@@ -66,7 +66,7 @@ If the Dealer is able to fulfill and allowing the registration, it answers by se
 where
 
 * `REGISTER.Request` is the ID from the original request.
-*  `Registration` is an ID chosen by the Dealer for the registration.
+* `Registration` is an ID chosen by the Dealer for the registration.
 
 *Example*
 


### PR DESCRIPTION
1. Changes `*Session*s` to `*Sessions*`;
2. Replace unicode `—` to ascii `-`;
3. Remove accident space and asterisk, insert missing space.