### PR TITLE
Fix error uris

### DIFF
--- a/rfc/text/advanced/uris.md
+++ b/rfc/text/advanced/uris.md
@@ -21,7 +21,7 @@ The *Client* attempted to authenticate for a non-existing *Realm* (`realm|string
 {align="left"}
         wamp.error.no_such_realm
 
-The *Client* authenticated for a non-existing *Principal* (`authid|string`).
+The *Client* attempted to authenticate for a non-existing *Principal* (`realm|string` and `authid|string` composite).
 
 {align="left"}
         wamp.error.no_such_principal

--- a/rfc/text/advanced/uris.md
+++ b/rfc/text/advanced/uris.md
@@ -21,11 +21,6 @@ The *Client* attempted to authenticate for a non-existing *Realm* (`realm|string
 {align="left"}
         wamp.error.no_such_realm
 
-The *Client* attempted to authenticate for a non-existing *Role* (`authrole|string`).
-
-{align="left"}
-        wamp.error.no_such_role
-
 The *Client* authenticated for a non-existing *Principal* (`authid|string`).
 
 {align="left"}


### PR DESCRIPTION
Two modifies here:

1. No auth method allow client pass `authrole`, so, never reach the `no_such_role` error;
2. `authid` maybe available but not in the session's realm, so need to verify `realm` and `authid` composite (or other word?)