### PR TITLE
Move call-canceling and call-timeout up.

### DIFF
--- a/rfc/text/advanced.md
+++ b/rfc/text/advanced.md
@@ -14,13 +14,13 @@
 
 {{advanced/rpc.md}}
 
-{{advanced/rpc_progressive_call_results.md}}
-
-{{advanced/rpc_progressive_call_invocations.md}}
+{{advanced/rpc_call_canceling.md}}
 
 {{advanced/rpc_call_timeout.md}}
 
-{{advanced/rpc_call_canceling.md}}
+{{advanced/rpc_progressive_call_results.md}}
+
+{{advanced/rpc_progressive_call_invocations.md}}
 
 {{advanced/rpc_call_rerouting.md}}
 

--- a/rfc/text/advanced/features.md
+++ b/rfc/text/advanced/features.md
@@ -7,10 +7,10 @@ Support for advanced features must be announced by the peers which implement the
 {align="left"}
 | Feature                                                           | Status | Caller | Dealer | Callee |
 |-------------------------------------------------------------------|--------|--------|--------|--------|
+| [Call Canceling](#rpc-call-canceling)                             | alpha  | X      | X      | X      |
+| [Call Timeout](#rpc-call-timeout)                                 | alpha  | X      | X      | X      |
 | [Progressive Call Results](#rpc-progressive-call-results)         | stable | X      | X      | X      |
 | [Progressive Call Invocations](#rpc-progressive-call-invocations) | alpha  | X      | X      | X      |
-| [Call Timeout](#rpc-call-timeout)                                 | alpha  | X      | X      | X      |
-| [Call Canceling](#rpc-call-canceling)                             | alpha  | X      | X      | X      |
 | [Caller Identification](#rpc-call-identification)                 | stable | X      | X      | X      |
 | [Call Trustlevels](#rpc-call-trust-levels)                        | alpha  |        | X      | X      |
 | [Registration Meta API](#rpc-reg-metapi)                          | beta   |        | X      |        |


### PR DESCRIPTION
Because call-timeout, progress-call all depend on call-canceling, so, move it up, friendly for new readers and implementers