### PR TITLE
Drop cancel(l)ed and cancel(l)ing's second L letter.

### DIFF
--- a/rfc/text/advanced/rpc_progressive_call_invocations.md
+++ b/rfc/text/advanced/rpc_progressive_call_invocations.md
@@ -20,16 +20,16 @@ and *Dealers* (`role := "dealer"`) via
         HELLO.Details.roles.<role>.features.progressive_call_invocations|bool := true
 
 Progressive call invocations can work only if all three peers support and announce this feature.
-In addition, *Callees* MUST announce support of the _Call Cancelling_ feature via
+In addition, *Callees* MUST announce support of the _Call Canceling_ feature via
 
 {align="left"}
-        HELLO.Details.roles.callee.features.call_cancelling|bool := true
+        HELLO.Details.roles.callee.features.call_canceling|bool := true
 
 
-As a consequence, *Dealers* MUST also announce support of the _Call Cancelling_ feature via
+As a consequence, *Dealers* MUST also announce support of the _Call Canceling_ feature via
 
 {align="left"}
-        WELCOME.Details.roles.dealer.features.call_cancelling|bool := true
+        WELCOME.Details.roles.dealer.features.call_canceling|bool := true
 
 The following cases, where a *Caller* sends a `CALL` message with `progress := true`, MUST be treated as *protocol errors*
 with the underlying WAMP sessions being aborted:
@@ -38,7 +38,7 @@ with the underlying WAMP sessions being aborted:
 - The *Dealer* did not announce the progressive call invocations feature during the `HELLO` handshake.
 
 Otherwise, in cases where the *Caller* sends a `CALL` message with `progress := true` but the *Callee* does not support
-progressive call invocations or call cancelling, the call MUST be treated as an *application error* with the *Dealer* responding
+progressive call invocations or call canceling, the call MUST be treated as an *application error* with the *Dealer* responding
 to the *Caller* with the `wamp.error.feature_not_supported` error message.
 
 **Message Flow**

--- a/rfc/text/basic/remote_procedure_call.md
+++ b/rfc/text/basic/remote_procedure_call.md
@@ -465,7 +465,7 @@ If either the *Dealer* or the *Callee* does not support the *Call Canceling* fea
 
 ## Callee Leaving During an RPC Invocation {#rpc-callee-leaving}
 
-After sending an INVOCATION message, if a *Dealer* detects that the *Callee* has left/disconnected without sending a final YIELD or ERROR response, then the *Dealer* SHALL return an ERROR message back to the Caller with a `wamp.error.cancelled` URI. The *Dealer* MAY provide additional information via the ERROR payload arguments to clarify that the cancellation is due to the *Callee* leaving before the call could be completed.
+After sending an INVOCATION message, if a *Dealer* detects that the *Callee* has left/disconnected without sending a final YIELD or ERROR response, then the *Dealer* SHALL return an ERROR message back to the Caller with a `wamp.error.canceled` URI. The *Dealer* MAY provide additional information via the ERROR payload arguments to clarify that the cancellation is due to the *Callee* leaving before the call could be completed.
 
 {align="left"}
         ,------.          ,------.          ,------.


### PR DESCRIPTION
After we discussed last time about `cancelled` should be `canceled`, I found another definition `cancelling` should be `canceling` which in autobahn implementation.

So, this PR, I replaced all of them in all texts, except word `cancellation`.